### PR TITLE
Fixed mixed-content in main.scss/main.css

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,5 +1,5 @@
 @import url(font-awesome.min.css);
-@import url("http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,700,900");
+@import url("//fonts.googleapis.com/css?family=Source+Sans+Pro:300,700,900");
 
 /*
 	Phantom by HTML5 UP

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -3,7 +3,7 @@
 @import 'libs/mixins';
 @import 'libs/skel';
 @import 'font-awesome.min.css';
-@import url('http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,700,900');
+@import url('//fonts.googleapis.com/css?family=Source+Sans+Pro:300,700,900');
 
 /*
 	Phantom by HTML5 UP


### PR DESCRIPTION
Set protocol-agnostic URI for Google Fonts to prevent mixed-content issues on sites running over SSL/TLS.

When using this theme over an SSL/TLS encrypted connection, Firefox and Chrome complain about mixed-content errors due to specifying the Google Font URI explicitly over HTTP. By removing the http: from the URI, the browser will load the font over the same protocol used by the website itself.
